### PR TITLE
Fix parse error of attributes in empty nodes

### DIFF
--- a/examples/graph.xml
+++ b/examples/graph.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<graph>
+    <node id="n1">
+        <label>Start</label>
+    </node>
+    <node id="n2"/>
+    <node id="n3"/>
+    <node id="n4"/>
+    <init ref="n1"/>
+    <edge id="e1" from="n1" to="n2"/>
+    <edge id="e2" from="n2" to="n3"/>
+    <edge id="e3" from="n3" to="n1"/>
+    <edge id="e4" from="n3" to="n4"/>
+    <edge id="e5" from="n4" to="n3"/>
+</graph>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,8 +135,15 @@ fn load_from_slice(string: &str) -> Result<Payload, Error> {
         }
     };
 
+    // Do not consider / of empty as a part
+    let attr_end = if &string[closing_del - 1..closing_del] == "/" {
+        closing_del - 1
+    } else {
+        closing_del
+    };
+
     let mut tag_parts =
-        SplitUnquoted::split(&string[opening_del + 1..closing_del], |c| c.is_whitespace());
+        SplitUnquoted::split(&string[opening_del + 1..attr_end], |c| c.is_whitespace());
 
     let tag_name = tag_parts.next().unwrap().trim();
 
@@ -151,11 +158,6 @@ fn load_from_slice(string: &str) -> Result<Payload, Error> {
 
     let mut attributes = HashMap::new();
     for part in tag_parts {
-        // Last closing of empty node
-        if part == "/" {
-            break;
-        }
-
         let equal_sign = match part.find("=") {
             Some(v) => v,
             None => {

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -43,4 +43,38 @@ mod tests {
             Ok(v) => v,
         };
     }
+
+    #[test]
+    fn parse_graph() {
+        let graph = simple_xml::from_file("./examples/graph.xml").expect("Failed to parse graph.xml");
+
+        assert_eq!(graph["node"].len(), 4);
+        assert_eq!(graph["node"][0].attributes["id"], "n1");
+        assert_eq!(graph["node"][0]["label"][0].content, "Start");
+        assert_eq!(graph["node"][1].attributes["id"], "n2");
+        assert_eq!(graph["node"][2].attributes["id"], "n3");
+        assert_eq!(graph["node"][3].attributes["id"], "n4");
+
+        assert_eq!(graph["init"][0].attributes["ref"], "n1");
+
+        assert_eq!(graph["edge"][0].attributes["id"], "e1");
+        assert_eq!(graph["edge"][0].attributes["from"], "n1");
+        assert_eq!(graph["edge"][0].attributes["to"], "n2");
+
+        assert_eq!(graph["edge"][1].attributes["id"], "e2");
+        assert_eq!(graph["edge"][1].attributes["from"], "n2");
+        assert_eq!(graph["edge"][1].attributes["to"], "n3");
+
+        assert_eq!(graph["edge"][2].attributes["id"], "e3");
+        assert_eq!(graph["edge"][2].attributes["from"], "n3");
+        assert_eq!(graph["edge"][2].attributes["to"], "n1");
+
+        assert_eq!(graph["edge"][3].attributes["id"], "e4");
+        assert_eq!(graph["edge"][3].attributes["from"], "n3");
+        assert_eq!(graph["edge"][3].attributes["to"], "n4");
+
+        assert_eq!(graph["edge"][4].attributes["id"], "e5");
+        assert_eq!(graph["edge"][4].attributes["from"], "n4");
+        assert_eq!(graph["edge"][4].attributes["to"], "n3");
+    }
 }


### PR DESCRIPTION
In empty nodes with no space between the last attribute's end quote and the backslash, the last attribute ends up containing the last quote. E.g. in `<node id="n1"/>` we get that `root["node"][0].attributes["id"] == "n1\""`.

I added a simple fix to better handle the baskslashes of empty nodes as well as a test. As seen in 1557971a4e083a9b3b0058e7c621d95ec957a4df, the test fails, while in the following commit 99f85b26c90f40e9d110a762c3ef2d3e63d7ba35, the test now pass.