### PR TITLE
Add support for comments

### DIFF
--- a/examples/comment.xml
+++ b/examples/comment.xml
@@ -1,0 +1,4 @@
+<!-- This is a comment  -->
+<message lang="eng">
+    <heading>Hello from XML</heading>
+</message>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ fn load_from_slice(string: &str) -> Result<Payload, Error> {
 
     // Is a comment
     // Attempt to read past comment
-    if &tag_name[0..1] == "?" {
+    if &tag_name[0..1] == "?" || &tag_name[0..1] == "!" {
         return load_from_slice(&string[closing_del + 1..]);
     }
 

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -45,6 +45,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_comment() {
+        let _comment = simple_xml::from_file("examples/comment.xml")
+            .expect("Failed to parse comment.xml");
+    }
+
+    #[test]
     fn parse_graph() {
         let graph =
             simple_xml::from_file("./examples/graph.xml").expect("Failed to parse graph.xml");


### PR DESCRIPTION
Hi,
simple-xml fails to parse files when they include comments (`<!-- comment -->`). This is a small patch to skip comments like it skips the XML declaration.